### PR TITLE
[FIX] Ya no es necesaria corrección. Arreglado en OCB commit df5f0f2570e9ab23be08b54a3f08ffe89ef735c2

### DIFF
--- a/eln_sale/sale.py
+++ b/eln_sale/sale.py
@@ -277,13 +277,6 @@ class sale_order_line(orm.Model):
             res['value']['product_uos_qty'] = 1.0
             res['value']['product_uos'] = uos
 
-        if context.get('uom_qty_change', False) and 'th_weight' not in res['value']:
-            # En Diciembre 2015 se añadió el valor en contexto 'uom_qty_change' 
-            # para evitar que al cambiar la cantidad de producto 
-            # se cambiase la unidad de medida
-            # pero no se tuvo en cuenta que el peso sí debe cambiar.
-            res['value']['th_weight'] = qty * prod_obj.weight
-
         return res
 
     def product_uom_change(self, cr, uid, ids, pricelist, product, qty=0,


### PR DESCRIPTION
[FIX] Ya no es necesaria corrección para cálculo del peso en los pedidos de venta al cambiar UdM. Se corrigió en OCB el 03/03/2017 en el commit df5f0f2570e9ab23be08b54a3f08ffe89ef735c2