### PR TITLE
Nuevo método de cálculo de la prioridad en las órdenes de producción. Añadido cron.

### DIFF
--- a/eln_production/__openerp__.py
+++ b/eln_production/__openerp__.py
@@ -40,6 +40,7 @@
     "init_xml" : [],
     "data" : [
                 'data/stock_production_lot_seq.xml',
+                'data/ir_cron.xml',
                 'mrp_workflow.xml',
                 'wizard/mrp_modify_consumption.xml',
                 'mrp_view.xml',

--- a/eln_production/data/ir_cron.xml
+++ b/eln_production/data/ir_cron.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data noupdate="1">
+
+        <record forcecreate="True" id="ir_cron_update production_priority" model="ir.cron">
+                <field name="name">Run update production priority</field>
+                <field eval="True" name="active"/>
+                <field name="user_id" ref="base.user_root"/>
+                <field name="interval_number">1</field>
+                <field name="interval_type">hours</field>
+                <field name="numbercall">-1</field>
+                <field eval="False" name="doall" />
+                <field eval="'mrp.production'" name="model" />
+                <field eval="'update_production_priority'" name="function" />
+                <field eval="'(False,)'" name="args" />
+        </record>
+
+    </data>
+</openerp>
+

--- a/eln_production/procurement.py
+++ b/eln_production/procurement.py
@@ -24,35 +24,11 @@ from openerp.osv import osv, fields
 class procurement_order(osv.osv):
     _inherit = 'procurement.order'
 
-    def _prepare_mo_vals(self, cr, uid, procurement, context=None):
-        res = super(procurement_order, self)._prepare_mo_vals(cr, uid, procurement, context=context)
-        if res: # Establecemos la prioridad de la producción
-            product_obj = self.pool.get('product.product')
-            product_available = product_obj._product_available(cr, uid, [procurement.product_id.id],
-                context={'location': procurement.location_id.id})[procurement.product_id.id]
-            qty_to_compare = product_available['qty_available'] - product_available['outgoing_qty']
-
-            orderpoint_obj = self.pool.get('stock.warehouse.orderpoint') 
-            company_id = res.get('company_id', False) or procurement[0].company_id.id
-            dom = company_id and [('company_id', '=', company_id)] or []
-            dom.append(('product_id', '=', procurement.product_id.id))
-            orderpoint_ids = orderpoint_obj.search(cr, uid, dom)
-            min_qty = max_qty = security_qty = 0
-            if orderpoint_ids:
-                op = orderpoint_obj.browse(cr, uid, orderpoint_ids[0], context=context)
-                min_qty = min(op.product_min_qty, op.product_max_qty)
-                max_qty = max(op.product_min_qty, op.product_max_qty)
-                security_qty = op.product_security_qty
-            
-            if qty_to_compare <= 0:
-                res.update(priority='2') # Urgente
-            elif qty_to_compare <= security_qty:
-                res.update(priority='1') # Normal
-            elif qty_to_compare <= min_qty:
-                res.update(priority='0') # No urgente
-            else:
-                res.update(priority='0') # No urgente
-
+    def make_mo(self, cr, uid, ids, context=None):
+        res = super(procurement_order, self).make_mo(cr, uid, ids, context=context)
+        for item in res:
+            if res[item]:
+                self.pool.get('mrp.production').update_production_priority(cr, uid, [res[item]], context)
         return res
-        
+
 procurement_order()


### PR DESCRIPTION
1. Se establece prioridad al crear la órden de fabricación desde planificadores (antes se hacía antes de crearla, y ahora se hace después).
2. Se pueden recalcular mediante cron las prioridades.